### PR TITLE
add NoisyPlayer for testing bots (does not hide stderr)

### DIFF
--- a/contests/2015_10_14_battleship/server/server_utils.py
+++ b/contests/2015_10_14_battleship/server/server_utils.py
@@ -103,3 +103,9 @@ class Player(object):
     def getClientProxy(self, other):
         s = subprocess.Popen(self.popen_args + [self.name, other.name], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self.cwd)
         return ClientProxy(self.name, s)
+
+#######################################################################
+class NoisyPlayer(Player):
+    def getClientProxy(self, other):
+        s = subprocess.Popen(self.popen_args + [self.name, other.name], stdin=subprocess.PIPE, stdout=subprocess.PIPE, cwd=self.cwd)
+        return ClientProxy(self.name, s)


### PR DESCRIPTION
I'm not sure if this is the best way to do this, but it's simple.  Basically doesn't turn subprocess's stderr into a pipe, so all that data actually gets dumped to the terminal.
