### PR TITLE
do not close stderr if it is not open

### DIFF
--- a/contests/2015_10_14_battleship/server/application.py
+++ b/contests/2015_10_14_battleship/server/application.py
@@ -47,10 +47,12 @@ def run_all_clients():
                 out_file.flush()
                 s.player1.client.stdin.close()
                 s.player1.client.stdout.close()
-                s.player1.client.stderr.close()
+                if s.player1.client.stderr:
+                    s.player1.client.stderr.close()
                 s.player2.client.stdin.close()
                 s.player2.client.stdout.close()
-                s.player2.client.stderr.close()
+                if s.player2.client.stderr:
+                    s.player2.client.stderr.close()
                 s.player1.client.kill()
                 s.player2.client.kill()
 


### PR DESCRIPTION
Allows NoisyPlayers to be run without specifying them on the command line.
